### PR TITLE
fix: improve YAUS example

### DIFF
--- a/yaus/mod.tsx
+++ b/yaus/mod.tsx
@@ -144,7 +144,7 @@ async function homePage(request: Request) {
   // populated when someone submits the form. We use this
   // information to either create a new short link or get
   // an existing short link for the url.
-  const { searchParams } = new URL(request.url);
+  const { protocol, host, searchParams } = new URL(request.url);
   const url = searchParams.get("url");
   if (url) {
     let code = await findCode(url);
@@ -197,7 +197,7 @@ async function homePage(request: Request) {
             </button>
           </form>
           {shortCode && <div className="link">
-            <span>{`https://yaus.deno.dev/${shortCode}`}</span>
+            <span>{`${protocol}//${host}/${shortCode}`}</span>
             <button id="clipboard">
               <img
                 height="32"


### PR DESCRIPTION
This PR improves YAUS (Yet Another URL Shortener) example. It uses its own host name for shortened url. It now works with preview deployments or deployctl runner.

<img width="800" alt="スクリーンショット 2021-03-29 16 53 44" src="https://user-images.githubusercontent.com/613956/112804702-abbe8b00-90af-11eb-9c63-1c44cd348e22.png">
