### PR TITLE
chore: upgrade sift

### DIFF
--- a/discord/mod.ts
+++ b/discord/mod.ts
@@ -5,7 +5,7 @@ import {
   json,
   serve,
   validateRequest,
-} from "https://deno.land/x/sift@0.4.0/mod.ts";
+} from "https://deno.land/x/sift@0.4.2/mod.ts";
 // TweetNaCl is a cryptography library that we use to verify requests
 // from Discord.
 import nacl from "https://cdn.skypack.dev/tweetnacl@v1.0.3";

--- a/issues/components/card.jsx
+++ b/issues/components/card.jsx
@@ -1,4 +1,4 @@
-import { h } from "https://deno.land/x/sift@0.4.0/mod.ts";
+import { h } from "https://deno.land/x/sift@0.4.2/mod.ts";
 import { formatDistanceToNow } from "https://cdn.skypack.dev/pin/date-fns@v2.16.1-IRhVs8UIgU3f9yS5Yt4w/date-fns.js";
 
 export default function Card({

--- a/issues/components/layout.jsx
+++ b/issues/components/layout.jsx
@@ -1,4 +1,4 @@
-import { h } from "https://deno.land/x/sift@0.4.0/mod.ts";
+import { h } from "https://deno.land/x/sift@0.4.2/mod.ts";
 
 export default function Layout({ children }) {
   return (

--- a/issues/components/search.jsx
+++ b/issues/components/search.jsx
@@ -1,4 +1,4 @@
-import { h } from "https://deno.land/x/sift@0.4.0/mod.ts";
+import { h } from "https://deno.land/x/sift@0.4.2/mod.ts";
 
 /** Validate if the form value follows the appropriate
  *  structure (<owner>/<repo>). */

--- a/issues/mod.js
+++ b/issues/mod.js
@@ -1,4 +1,4 @@
-import { serve } from "https://deno.land/x/sift@0.4.0/mod.ts";
+import { serve } from "https://deno.land/x/sift@0.4.2/mod.ts";
 import homePage from "./pages/home.jsx";
 import notFoundPage from "./pages/404.jsx";
 import issuesEndpoint from "./pages/api/issues.js";

--- a/issues/pages/404.jsx
+++ b/issues/pages/404.jsx
@@ -1,4 +1,4 @@
-import { h } from "https://deno.land/x/sift@0.4.0/mod.ts";
+import { h } from "https://deno.land/x/sift@0.4.2/mod.ts";
 import Layout from "../components/layout.jsx";
 
 export default function notFoundPage(request) {

--- a/issues/pages/api/issues.js
+++ b/issues/pages/api/issues.js
@@ -1,4 +1,4 @@
-import { json, validateRequest } from "https://deno.land/x/sift@0.4.0/mod.ts";
+import { json, validateRequest } from "https://deno.land/x/sift@0.4.2/mod.ts";
 import repositories from "../../data/repositories.js";
 
 export default async function issuesEndpoint(request) {

--- a/issues/pages/home.jsx
+++ b/issues/pages/home.jsx
@@ -1,4 +1,4 @@
-import { h } from "https://deno.land/x/sift@0.4.0/mod.ts";
+import { h } from "https://deno.land/x/sift@0.4.2/mod.ts";
 import Card from "../components/card.jsx";
 import Layout from "../components/layout.jsx";
 import Search from "../components/search.jsx";

--- a/slack/mod.ts
+++ b/slack/mod.ts
@@ -2,7 +2,7 @@ import {
   json,
   serve,
   validateRequest,
-} from "https://deno.land/x/sift@0.4.0/mod.ts";
+} from "https://deno.land/x/sift@0.4.2/mod.ts";
 import { getCardinal } from "https://deno.land/x/cardinal@0.1.0/mod.ts";
 import { getRandomCity } from "./cities.ts";
 

--- a/telegram/mod.ts
+++ b/telegram/mod.ts
@@ -3,7 +3,7 @@ import {
   PathParams,
   serve,
   validateRequest,
-} from "https://deno.land/x/sift@0.4.0/mod.ts";
+} from "https://deno.land/x/sift@0.4.2/mod.ts";
 
 // For all requests to "/<TOKEN>" endpoint, we want to invoke handleTelegram() handler.
 // Recommend using a secret path in the URL, e.g. https://www.example.com/<token>.

--- a/yaus/mod.tsx
+++ b/yaus/mod.tsx
@@ -4,7 +4,7 @@ import {
   jsx,
   PathParams,
   serve,
-} from "https://deno.land/x/sift@0.4.0/mod.ts";
+} from "https://deno.land/x/sift@0.4.2/mod.ts";
 import { nanoid } from "https://cdn.esm.sh/v14/nanoid@3.1.20/esnext/nanoid.js";
 
 serve({


### PR DESCRIPTION
The examples are broken due to missing dependency in old version of sift. The upgrade fixes it.
